### PR TITLE
Implementing proper pointer freeing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.3.1)
 project(imresh)
 
 # Options

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ To compile this library you need
 
 * C++ Compiler (with `c++11` support)
 
-* CUDA (`7.5+`)
+* CUDA (`7.0+`)
 
-* CMake (`3.3+`)
+* CMake (`3.3.1+`)
 
 * OpenMP
 
@@ -67,9 +67,13 @@ To compile this library you need
 
         cmake ..
 
+    For a clean build with debugging information, try
+
+        cmake .. -DIMRESH_DEBUG=on -DBUILD_DOC=off
+
     To build and run everything, try
 
-        cmake .. -DRUN_TESTS=on -DBUILD_EXAMPLES=on
+        cmake .. -DRUN_TESTS=on -DBUILD_EXAMPLES=on -DUSE_PNG=on -DUSE_SPLASH=on
 
 3. Invoking make
 
@@ -109,7 +113,7 @@ where image loading and writing can also be handled outside the library.
 
     > Your self-written functions have to provide you both the image dimensions
     > and the host memory containing the image. This memory has to be allocated
-    > via `cudaMallocHost` in order to ensure _imresh_'s correct behaviour.
+    > via `new` if you're using the built-in write-out functions.
 
 3. Image processing is just a call to `imresh::io::addTask( )` (for explanation
     of the parameters please have a look at the Doxygen). This will start a
@@ -127,6 +131,19 @@ where image loading and writing can also be handled outside the library.
     (`size.first` is horizontal, `size.second` is vertical) and `filename` the
     name of the file to store the image in.
 
+    > _Note:_
+
+    > If you're using _imresh_'s own loading functions in combination with your
+    > own write-out functions be sure you're freeing the image memory with
+    > `delete`.
+
+    > _Note:_
+
+    > _imresh_'s workflow is designed in a way that you'd free your memory inside
+    > of your write out function. It's never called before the algorithm finishs
+    > and therefore the ideal place for freeing the image data. _imresh_'s
+    > built-in functions handle it that way.
+
 5. Library deinitialization is again just a call to `imresh::io::taskQueueDeinit( )`.
     This will handle stream destroying, memory freeing and so on for you.
 
@@ -134,6 +151,22 @@ where image loading and writing can also be handled outside the library.
 
     > When you're using your own data reading and/or writing functions, you'll
     > have to handle the memory inside of this functions yourself.
+
+### Advanced usage
+
+There's a set of in-action examples in the `examples` directory. These can be
+compiled by appending the `-DBUILD_EXAMPLES=on` to your CMake call, e.g.
+
+    cmake .. -DBUILD_EXAMPLES=on
+
+1. For a simple but complete example of how to use this library try `miniExample`
+    and have a look at `miniExample.cpp`.
+
+2. For a more complex example with batch processing please have a look at
+    `threadedExample` and `threadedExamples.cpp` resp.
+
+3. If you need more example data for your tests, please run
+    `outputExampleCreation`
 
 ## Authors
 

--- a/examples/miniExample.cpp
+++ b/examples/miniExample.cpp
@@ -35,33 +35,33 @@
 
 int main( void )
 {
-    std::vector<unsigned> imageSize { 300, 300 };
-    std::pair<unsigned,unsigned> imageSizePair{ imageSize[0], imageSize[1] };
+    std::vector<unsigned int> imageSize { 300, 300 };
+    std::pair<unsigned int,unsigned int> imageSizePair{ imageSize[0], imageSize[1] };
     using namespace examples::createTestData;
     float * pAtomCluster = createAtomCluster( imageSize[0], imageSize[1] );
 
     /* debug output of image */
     std::ofstream file;
-    file.open("atomClusterInput.dat");
-    for ( unsigned ix = 0; ix < imageSize[0]; ++ix )
+    file.open( "atomClusterInput.dat" );
+    for( unsigned int ix = 0; ix < imageSize[0]; ++ix )
     {
-        for ( unsigned iy = 0; iy < imageSize[1]; ++iy )
+        for( unsigned int iy = 0; iy < imageSize[1]; ++iy )
             file << std::setw(10) << pAtomCluster[ iy*imageSize[0] + ix ] << " ";
         file << "\n";
     }
-    file.close();
+    file.close( );
     std::cout << "Wrote atomClusterInput to atomClusterInput.dat\n";
 
     imresh::libs::diffractionIntensity( pAtomCluster, imageSizePair );
 
-    file.open("diffractionIntensity.dat");
-    for ( unsigned ix = 0; ix < imageSize[0]; ++ix )
+    file.open( "diffractionIntensity.dat" );
+    for( unsigned int ix = 0; ix < imageSize[0]; ++ix )
     {
-        for ( unsigned iy = 0; iy < imageSize[1]; ++iy )
+        for( unsigned int iy = 0; iy < imageSize[1]; ++iy )
             file << std::setw(10) << pAtomCluster[ iy*imageSize[0] + ix ] << " ";
         file << "\n";
     }
-    file.close();
+    file.close( );
     std::cout << "Wrote diffractionIntensity to diffractionIntensity.dat\n";
 
     imresh::algorithms::shrinkWrap( pAtomCluster, imageSize, 64 /*cycles*/, 1e-6 /* targetError */ );
@@ -70,14 +70,14 @@ int main( void )
      * you could compare the current state with the data returned by
      * createAtomCluster now */
 
-    file.open("atomClusterOutput.dat");
-    for ( unsigned ix = 0; ix < imageSize[0]; ++ix )
+    file.open( "atomClusterOutput.dat" );
+    for( unsigned int ix = 0; ix < imageSize[0]; ++ix )
     {
-        for ( unsigned iy = 0; iy < imageSize[1]; ++iy )
+        for( unsigned int iy = 0; iy < imageSize[1]; ++iy )
             file << std::setw(10) << pAtomCluster[ iy*imageSize[0] + ix ] << " ";
         file << "\n";
     }
-    file.close();
+    file.close( );
     std::cout << "Wrote atomClusterOutput to atomClusterOutput.dat\n";
 
 

--- a/examples/outputExampleCreation.cpp
+++ b/examples/outputExampleCreation.cpp
@@ -42,9 +42,9 @@ namespace examples
 
     void saveToPng
     (
-        float const * const data,
-        std::pair< unsigned, unsigned > const & size,
-        std::string const & filename
+        float* data,
+        std::pair<unsigned int,unsigned int> const& size,
+        std::string const& filename
     )
     {
 #       ifdef USE_PNG

--- a/examples/outputExampleCreation.cpp
+++ b/examples/outputExampleCreation.cpp
@@ -42,9 +42,9 @@ namespace examples
 
     void saveToPng
     (
-        float* data,
+        float * data,
         std::pair<unsigned int,unsigned int> const& size,
-        std::string const& filename
+        std::string const filename
     )
     {
 #       ifdef USE_PNG

--- a/examples/outputExampleCreation.cpp
+++ b/examples/outputExampleCreation.cpp
@@ -48,10 +48,8 @@ namespace examples
     )
     {
 #       ifdef USE_PNG
-            //std::cout << "size = (" << size.first << "," << size.second << ")\n";
             imresh::io::writeOutFuncs::writeOutPNG( data, size, filename );
 #       endif
-        delete[] data;
     }
 
 

--- a/examples/threadedExample.cpp
+++ b/examples/threadedExample.cpp
@@ -56,7 +56,7 @@ int main( void )
 #   else
         using namespace examples::createTestData;
         std::pair<unsigned,unsigned> imageSize { 300, 300 };
-        std::pair< float*, std::pair<unsigned,unsigned> > file
+        std::pair<float*,std::pair<unsigned,unsigned>> file
         {
             createAtomCluster( imageSize.first, imageSize.second ),
             imageSize
@@ -64,7 +64,13 @@ int main( void )
 #   endif
     // This step is only needed because we have no real images
     imresh::libs::diffractionIntensity( file.first, file.second );
-    delete[] file.first;
+    // And now we free it again.
+    if( file.first != NULL )
+    {
+        delete[] file.first;
+        file.first = NULL;
+    }
+
 
     // Now let's test the PNG in- and output
 #   ifdef USE_PNG
@@ -80,7 +86,7 @@ int main( void )
             filename << "imresh_" << std::setw( 2 ) << std::setfill( '0' )
                      << i << "_cycles.png";
             imresh::io::addTask( file.first, file.second,
-                                 dummyWriteOutFunc, //imresh::io::writeOutFuncs::writeOutPNG,
+                                 imresh::io::writeOutFuncs::writeOutPNG,
                                  filename.str(),
                                  i /* sets the number of iterations */ );
         }

--- a/examples/threadedExample.cpp
+++ b/examples/threadedExample.cpp
@@ -46,8 +46,8 @@ int main( void )
         auto file = imresh::io::readInFuncs::readHDF5( "../examples/testData/imresh" );
 #   else
         using namespace examples::createTestData;
-        std::pair<unsigned,unsigned> imageSize { 300, 300 };
-        std::pair<float*,std::pair<unsigned,unsigned>> file
+        std::pair<unsigned int,unsigned int> imageSize { 300, 300 };
+        std::pair<float *,std::pair<unsigned int,unsigned int>> file
         {
             createAtomCluster( imageSize.first, imageSize.second ),
             imageSize

--- a/examples/threadedExample.cpp
+++ b/examples/threadedExample.cpp
@@ -36,15 +36,6 @@
 #endif
 
 
-
-void dummyWriteOutFunc(
-    float const * const _mem,
-    std::pair<unsigned, unsigned> const _size,
-    std::string const _filename
-)
-{}
-
-
 int main( void )
 {
     // First step is to initialize the library.
@@ -52,7 +43,7 @@ int main( void )
 
 #   ifdef USE_SPLASH
         // Read in a HDF5 file containing a grey scale image as a table
-        auto file = imresh::io::readInFuncs::readHDF5( "../examples/imresh" );
+        auto file = imresh::io::readInFuncs::readHDF5( "../examples/testData/imresh" );
 #   else
         using namespace examples::createTestData;
         std::pair<unsigned,unsigned> imageSize { 300, 300 };
@@ -85,10 +76,11 @@ int main( void )
             std::ostringstream filename;
             filename << "imresh_" << std::setw( 2 ) << std::setfill( '0' )
                      << i << "_cycles.png";
-            imresh::io::addTask( file.first, file.second,
-                                 imresh::io::writeOutFuncs::writeOutPNG,
-                                 filename.str(),
-                                 i /* sets the number of iterations */ );
+            imresh::io::addTask( file.first,
+                                  file.second,
+                                  imresh::io::writeOutFuncs::writeOutPNG,
+                                  filename.str(),
+                                  i /* sets the number of iterations */ );
         }
 #   endif
 

--- a/src/imresh/io/readInFuncs/readInFuncs.cpp
+++ b/src/imresh/io/readInFuncs/readInFuncs.cpp
@@ -52,7 +52,7 @@ namespace readInFuncs
 
     std::pair<float*,std::pair<unsigned int,unsigned int>>
     readTxt(
-        std::string const _filename
+        std::string const& _filename
     )
     {
         std::ifstream file;
@@ -108,7 +108,7 @@ namespace readInFuncs
 #   ifdef USE_PNG
         std::pair<float*,std::pair<unsigned int,unsigned int>>
         readPNG(
-            std::string const _filename
+            std::string const& _filename
         )
         {
             pngwriter png( 1, 1, 0, "tmp.png" );
@@ -159,7 +159,7 @@ namespace readInFuncs
 #   ifdef USE_SPLASH
         std::pair<float*,std::pair<unsigned int,unsigned int>>
         readHDF5(
-            std::string const _filename
+            std::string const& _filename
         )
         {
             splash::SerialDataCollector sdc( 0 );

--- a/src/imresh/io/readInFuncs/readInFuncs.cpp
+++ b/src/imresh/io/readInFuncs/readInFuncs.cpp
@@ -52,7 +52,7 @@ namespace readInFuncs
 
     std::pair<float *,std::pair<unsigned int,unsigned int>>
     readTxt(
-        std::string const _filename
+        std::string const& _filename
     )
     {
         std::ifstream file;
@@ -108,7 +108,7 @@ namespace readInFuncs
 #   ifdef USE_PNG
         std::pair<float *,std::pair<unsigned int,unsigned int>>
         readPNG(
-            std::string const _filename
+            std::string const& _filename
         )
         {
             pngwriter png( 1, 1, 0, "tmp.png" );
@@ -159,7 +159,7 @@ namespace readInFuncs
 #   ifdef USE_SPLASH
         std::pair<float *,std::pair<unsigned int,unsigned int>>
         readHDF5(
-            std::string const _filename
+            std::string const& _filename
         )
         {
             splash::SerialDataCollector sdc( 0 );

--- a/src/imresh/io/readInFuncs/readInFuncs.cpp
+++ b/src/imresh/io/readInFuncs/readInFuncs.cpp
@@ -50,9 +50,9 @@ namespace readInFuncs
 {
 
 
-    std::pair<float*,std::pair<unsigned int,unsigned int>>
+    std::pair<float *,std::pair<unsigned int,unsigned int>>
     readTxt(
-        std::string const& _filename
+        std::string const _filename
     )
     {
         std::ifstream file;
@@ -88,7 +88,7 @@ namespace readInFuncs
                 strList.pop_front( );
             }
 
-            auto ret = std::make_pair( (float*) retArray, std::make_pair( xDim, yDim ) );
+            auto ret = std::make_pair( (float *) retArray, std::make_pair( xDim, yDim ) );
 #           ifdef IMRESH_DEBUG
                 std::cout << "imresh::io::readInFuncs::readTxt(): Successfully read file."
                     << std::endl;
@@ -106,9 +106,9 @@ namespace readInFuncs
     }
 
 #   ifdef USE_PNG
-        std::pair<float*,std::pair<unsigned int,unsigned int>>
+        std::pair<float *,std::pair<unsigned int,unsigned int>>
         readPNG(
-            std::string const& _filename
+            std::string const _filename
         )
         {
             pngwriter png( 1, 1, 0, "tmp.png" );
@@ -127,7 +127,7 @@ namespace readInFuncs
                 return { NULL, { 0, 0 } };
             }
 
-            float* mem = new float[x * y];
+            float * mem = new float[x * y];
             for( auto i = 0; i < y; i++ )
             {
                 for( auto j = 0; j < x; j++ )
@@ -157,9 +157,9 @@ namespace readInFuncs
 #   endif
 
 #   ifdef USE_SPLASH
-        std::pair<float*,std::pair<unsigned int,unsigned int>>
+        std::pair<float *,std::pair<unsigned int,unsigned int>>
         readHDF5(
-            std::string const& _filename
+            std::string const _filename
         )
         {
             splash::SerialDataCollector sdc( 0 );
@@ -170,9 +170,9 @@ namespace readInFuncs
 
             sdc.open( _filename.c_str( ), fCAttr );
 
-            int32_t *ids = NULL;
+            int32_t * ids = NULL;
             size_t num_ids = 0;
-            sdc.getEntryIDs( NULL, &num_ids );
+            sdc.getEntryIDs( NULL, & num_ids );
 
             if( num_ids == 0 )
             {
@@ -186,10 +186,10 @@ namespace readInFuncs
             else
             {
                 ids = new int32_t[num_ids];
-                sdc.getEntryIDs( ids, &num_ids );
+                sdc.getEntryIDs( ids, & num_ids );
             }
 
-            splash::DataCollector::DCEntry *entries = NULL;
+            splash::DataCollector::DCEntry * entries = NULL;
             size_t num_entries = 0;
             sdc.getEntriesForID( ids[0], NULL, &num_entries );
 
@@ -215,7 +215,7 @@ namespace readInFuncs
             splash::Dimensions dim;
             sdc.read( ids[0], first_entry.name.c_str( ), dim, NULL );
 
-            float* mem = NULL;
+            float * mem = NULL;
             if( dim.getScalarSize( ) == 0 )
             {
                 delete[] entries;

--- a/src/imresh/io/readInFuncs/readInFuncs.cpp
+++ b/src/imresh/io/readInFuncs/readInFuncs.cpp
@@ -52,7 +52,7 @@ namespace readInFuncs
 
     std::pair<float *,std::pair<unsigned int,unsigned int>>
     readTxt(
-        std::string const& _filename
+        std::string const _filename
     )
     {
         std::ifstream file;
@@ -108,7 +108,7 @@ namespace readInFuncs
 #   ifdef USE_PNG
         std::pair<float *,std::pair<unsigned int,unsigned int>>
         readPNG(
-            std::string const& _filename
+            std::string const _filename
         )
         {
             pngwriter png( 1, 1, 0, "tmp.png" );
@@ -159,7 +159,7 @@ namespace readInFuncs
 #   ifdef USE_SPLASH
         std::pair<float *,std::pair<unsigned int,unsigned int>>
         readHDF5(
-            std::string const& _filename
+            std::string const _filename
         )
         {
             splash::SerialDataCollector sdc( 0 );

--- a/src/imresh/io/readInFuncs/readInFuncs.hpp
+++ b/src/imresh/io/readInFuncs/readInFuncs.hpp
@@ -46,7 +46,7 @@ namespace readInFuncs
     std::pair<float *,std::pair<unsigned int,unsigned int>>
     readTxt
     (
-        std::string const _filename
+        std::string const& _filename
     );
 
 #   ifdef USE_PNG
@@ -62,7 +62,7 @@ namespace readInFuncs
         std::pair<float *,std::pair<unsigned int,unsigned int>>
         readPNG
         (
-            std::string const _filename
+            std::string const& _filename
         );
 #   endif
 
@@ -75,7 +75,7 @@ namespace readInFuncs
         std::pair<float *,std::pair<unsigned int,unsigned int>>
         readHDF5
         (
-            std::string const _filename
+            std::string const& _filename
         );
 #   endif
 

--- a/src/imresh/io/readInFuncs/readInFuncs.hpp
+++ b/src/imresh/io/readInFuncs/readInFuncs.hpp
@@ -46,7 +46,7 @@ namespace readInFuncs
     std::pair<float *,std::pair<unsigned int,unsigned int>>
     readTxt
     (
-        std::string const& _filename
+        std::string const _filename
     );
 
 #   ifdef USE_PNG
@@ -62,7 +62,7 @@ namespace readInFuncs
         std::pair<float *,std::pair<unsigned int,unsigned int>>
         readPNG
         (
-            std::string const& _filename
+            std::string const _filename
         );
 #   endif
 
@@ -75,7 +75,7 @@ namespace readInFuncs
         std::pair<float *,std::pair<unsigned int,unsigned int>>
         readHDF5
         (
-            std::string const& _filename
+            std::string const _filename
         );
 #   endif
 

--- a/src/imresh/io/readInFuncs/readInFuncs.hpp
+++ b/src/imresh/io/readInFuncs/readInFuncs.hpp
@@ -41,38 +41,41 @@ namespace readInFuncs
      * Simple function for reading txt files.
      *
      * They need to store their values as a 2D matrix with spaces as delimiters.
+     * _Note:_ This is currently not working!
      */
-    std::pair<float *, std::pair<unsigned int, unsigned int> >
+    std::pair<float*,std::pair<unsigned int,unsigned int>>
     readTxt
     (
-        std::string const _filename
+        std::string const& _filename
     );
 
 #   ifdef USE_PNG
         /**
-         * Reads date from PNG
+         * Reads data from PNG.
          *
          * @param[in] path to filename
          * @return pair where first contains pointer to data. NULL on error
          *         e.g. allocation problem or couldn't open file.
          *         second pair element contains 2d dimension values as pair.
          *         They are 0 on error.
-         **/
-        std::pair<float *, std::pair<unsigned int,unsigned int> >
+         */
+        std::pair<float*,std::pair<unsigned int,unsigned int>>
         readPNG
         (
-            std::string const _filename
+            std::string const& _filename
         );
 #   endif
 
 #   ifdef USE_SPLASH
         /**
          * @see readPNG
+         *
+         * _Note:_ This is currently not working!
          **/
-        std::pair<float *,std::pair<unsigned int,unsigned int> >
+        std::pair<float*,std::pair<unsigned int,unsigned int>>
         readHDF5
         (
-            std::string const _filename
+            std::string const& _filename
         );
 #   endif
 

--- a/src/imresh/io/readInFuncs/readInFuncs.hpp
+++ b/src/imresh/io/readInFuncs/readInFuncs.hpp
@@ -43,10 +43,10 @@ namespace readInFuncs
      * They need to store their values as a 2D matrix with spaces as delimiters.
      * _Note:_ This is currently not working!
      */
-    std::pair<float*,std::pair<unsigned int,unsigned int>>
+    std::pair<float *,std::pair<unsigned int,unsigned int>>
     readTxt
     (
-        std::string const& _filename
+        std::string const _filename
     );
 
 #   ifdef USE_PNG
@@ -59,10 +59,10 @@ namespace readInFuncs
          *         second pair element contains 2d dimension values as pair.
          *         They are 0 on error.
          */
-        std::pair<float*,std::pair<unsigned int,unsigned int>>
+        std::pair<float *,std::pair<unsigned int,unsigned int>>
         readPNG
         (
-            std::string const& _filename
+            std::string const _filename
         );
 #   endif
 
@@ -72,10 +72,10 @@ namespace readInFuncs
          *
          * _Note:_ This is currently not working!
          **/
-        std::pair<float*,std::pair<unsigned int,unsigned int>>
+        std::pair<float *,std::pair<unsigned int,unsigned int>>
         readHDF5
         (
-            std::string const& _filename
+            std::string const _filename
         );
 #   endif
 

--- a/src/imresh/io/taskQueue.cu
+++ b/src/imresh/io/taskQueue.cu
@@ -224,6 +224,7 @@ namespace io
         for( int i = 0; i < deviceCount; i++ )
         {
             cudaDeviceProp prop;
+            CUDA_ERROR( cudaSetDevice( i ) );
             CUDA_ERROR( cudaGetDeviceProperties( &prop, i ) );
 
             assert( prop.multiProcessorCount >= 0 );

--- a/src/imresh/io/taskQueue.cu
+++ b/src/imresh/io/taskQueue.cu
@@ -84,9 +84,9 @@ namespace io
      * @see addTask
      */
     void addTaskAsync(
-        float* _h_mem,
+        float * _h_mem,
         std::pair<unsigned int,unsigned int> _size,
-        std::function<void(float*,std::pair<unsigned int,unsigned int>,
+        std::function<void(float *,std::pair<unsigned int,unsigned int>,
             std::string)> _writeOutFunc,
         std::string _filename,
         unsigned int _numberOfCycles,
@@ -106,7 +106,7 @@ namespace io
         auto strm = streamList.front( );
         streamList.pop_front( );
         streamList.push_back( strm );
-        mtx.unlock();
+        mtx.unlock( );
         auto device = strm.device;
         auto str = strm.str;
 
@@ -141,9 +141,9 @@ namespace io
     }
 
     void addTask(
-        float* _h_mem,
+        float * _h_mem,
         std::pair<unsigned int,unsigned int> _size,
-        std::function<void(float*,std::pair<unsigned int,unsigned int>,
+        std::function<void(float *,std::pair<unsigned int,unsigned int>,
             std::string)> _writeOutFunc,
         std::string _filename,
         unsigned int _numberOfCycles = 20,
@@ -164,7 +164,7 @@ namespace io
                 std::cout << "imresh::io::addTask(): Too many active threads. Waiting for one of them to finish."
                     << std::endl;
 #           endif
-            if ( threadPool.front().joinable() )
+            if ( threadPool.front( ).joinable( ) )
                 threadPool.front( ).join( );
             else
             {
@@ -210,7 +210,7 @@ namespace io
                 << std::endl;
 #       endif
         int deviceCount = 0;
-        CUDA_ERROR( cudaGetDeviceCount( &deviceCount ) );
+        CUDA_ERROR( cudaGetDeviceCount( & deviceCount ) );
 
         if( deviceCount <= 0 )
         {
@@ -225,7 +225,7 @@ namespace io
         {
             cudaDeviceProp prop;
             CUDA_ERROR( cudaSetDevice( i ) );
-            CUDA_ERROR( cudaGetDeviceProperties( &prop, i ) );
+            CUDA_ERROR( cudaGetDeviceProperties( & prop, i ) );
 
             assert( prop.multiProcessorCount >= 0 );
 #           ifdef IMRESH_DEBUG
@@ -240,7 +240,7 @@ namespace io
             {
                 stream str;
                 str.device = i;
-                CUDA_ERROR( cudaStreamCreate( &str.str ) );
+                CUDA_ERROR( cudaStreamCreate( & str.str ) );
                 streamList.push_back( str );
 #               ifdef IMRESH_DEBUG
                     std::cout << "imresh::io::fillStreamList(): Created stream "

--- a/src/imresh/io/taskQueue.hpp
+++ b/src/imresh/io/taskQueue.hpp
@@ -51,9 +51,9 @@ namespace io
      * @param _targetError The target error to stop the program when reached.
      */
     void addTask(
-        float* _h_mem,
+        float * _h_mem,
         std::pair<unsigned int,unsigned int> _size,
-        std::function<void(float*,std::pair<unsigned int,unsigned int>,
+        std::function<void(float *,std::pair<unsigned int,unsigned int>,
             std::string)> _writeOutFunc,
         std::string _filename,
         unsigned int _numberOfCycles = 20,

--- a/src/imresh/io/writeOutFuncs/writeOutFuncs.cpp
+++ b/src/imresh/io/writeOutFuncs/writeOutFuncs.cpp
@@ -53,14 +53,14 @@ namespace writeOutFuncs
 
     void justFree
     (
-        float * _mem,
-        std::pair<unsigned, unsigned> const _size,
+        float* _mem,
+        std::pair<unsigned int,unsigned int> const _size,
         std::string const _filename
     )
     {
-        if ( _mem != NULL )
+        if( _mem != NULL )
         {
-            free( _mem );
+            delete[] _mem;
             _mem = NULL;
         }
 #       ifdef IMRESH_DEBUG
@@ -72,32 +72,40 @@ namespace writeOutFuncs
 #   ifdef USE_PNG
         void writeOutPNG
         (
-            float const * const _mem,
-            std::pair<unsigned,unsigned> const _size,
+            float* _mem,
+            std::pair<unsigned int,unsigned int> const _size,
             std::string const _filename
         )
         {
-            auto const & Nx = _size.first;
-            auto const & Ny = _size.second;
+            pngwriter png( _size.first, _size.second, 0, _filename.c_str( ) );
 
-            pngwriter png( Nx, Ny, 0, _filename.c_str( ) );
-
-            float max = algorithms::vectorMax( _mem, Nx * Ny );
-            for( unsigned iy = 0; iy < Ny; ++iy )
+            float max = algorithms::vectorMax( _mem,
+                                        _size.first * _size.second );
+            for( unsigned int iy = 0; iy < _size.second; ++iy )
             {
-                for( unsigned ix = 0; ix < Nx; ++ix )
+                for( unsigned int ix = 0; ix < _size.first; ++ix )
                 {
-                    auto const index = iy * Nx + ix;
-                    assert( index < Nx * Ny );
-                    const auto & value = _mem[index] / max;
+                    auto const index = iy * _size.first + ix;
+                    assert( index < _size.first * _size.second );
+                    const auto& value = _mem[index] / max;
                     if ( not ( value == value ) ) // isNaN
+                    {
                         png.plot( ix, iy, 255, 0, 0 );
+                    }
                     else
+                    {
                         png.plot( ix, iy, value, value, value );
+                    }
                 }
             }
 
             png.close( );
+
+            if( _mem != NULL )
+            {
+                delete[] _mem;
+                _mem = NULL;
+            }
 #           ifdef IMRESH_DEBUG
                 std::cout << "imresh::io::writeOutFuncs::writeOutPNG(): "
                              "Successfully written image data to PNG ("
@@ -109,8 +117,8 @@ namespace writeOutFuncs
 #   ifdef USE_SPLASH
         void writeOutHDF5
         (
-            float const * const _mem,
-            std::pair<unsigned, unsigned> const _size,
+            float* _mem,
+            std::pair<unsigned int,unsigned int> const _size,
             std::string const _filename
         )
         {
@@ -133,6 +141,12 @@ namespace writeOutFuncs
                        _mem );
 
             sdc.close( );
+
+            if( _mem != NULL )
+            {
+                delete[] _mem;
+                _mem = NULL;
+            }
 #           ifdef IMRESH_DEBUG
                 std::cout << "imresh::io::writeOutFuncs::writeOutHDF5(): "
                              "Successfully written image data to HDF5 ("

--- a/src/imresh/io/writeOutFuncs/writeOutFuncs.cpp
+++ b/src/imresh/io/writeOutFuncs/writeOutFuncs.cpp
@@ -53,15 +53,14 @@ namespace writeOutFuncs
 
     void justFree
     (
-        float* _mem,
-        std::pair<unsigned int,unsigned int> const& _size,
-        std::string const& _filename
+        float * _mem,
+        std::pair<unsigned int,unsigned int> const _size,
+        std::string const _filename
     )
     {
         if( _mem != NULL )
         {
             delete[] _mem;
-            _mem = NULL;
         }
 #       ifdef IMRESH_DEBUG
             std::cout << "imresh::io::writeOutFuncs::justFree(): Freeing data ("
@@ -72,9 +71,9 @@ namespace writeOutFuncs
 #   ifdef USE_PNG
         void writeOutPNG
         (
-            float* _mem,
-            std::pair<unsigned int,unsigned int> const& _size,
-            std::string const& _filename
+            float * _mem,
+            std::pair<unsigned int,unsigned int> const _size,
+            std::string const _filename
         )
         {
             pngwriter png( _size.first, _size.second, 0, _filename.c_str( ) );
@@ -104,7 +103,6 @@ namespace writeOutFuncs
             if( _mem != NULL )
             {
                 delete[] _mem;
-                _mem = NULL;
             }
 #           ifdef IMRESH_DEBUG
                 std::cout << "imresh::io::writeOutFuncs::writeOutPNG(): "
@@ -117,9 +115,9 @@ namespace writeOutFuncs
 #   ifdef USE_SPLASH
         void writeOutHDF5
         (
-            float* _mem,
-            std::pair<unsigned int,unsigned int> const& _size,
-            std::string const& _filename
+            float * _mem,
+            std::pair<unsigned int,unsigned int> const _size,
+            std::string const _filename
         )
         {
             splash::SerialDataCollector sdc( 0 );
@@ -145,7 +143,6 @@ namespace writeOutFuncs
             if( _mem != NULL )
             {
                 delete[] _mem;
-                _mem = NULL;
             }
 #           ifdef IMRESH_DEBUG
                 std::cout << "imresh::io::writeOutFuncs::writeOutHDF5(): "

--- a/src/imresh/io/writeOutFuncs/writeOutFuncs.cpp
+++ b/src/imresh/io/writeOutFuncs/writeOutFuncs.cpp
@@ -54,8 +54,8 @@ namespace writeOutFuncs
     void justFree
     (
         float* _mem,
-        std::pair<unsigned int,unsigned int> const _size,
-        std::string const _filename
+        std::pair<unsigned int,unsigned int> const& _size,
+        std::string const& _filename
     )
     {
         if( _mem != NULL )
@@ -73,8 +73,8 @@ namespace writeOutFuncs
         void writeOutPNG
         (
             float* _mem,
-            std::pair<unsigned int,unsigned int> const _size,
-            std::string const _filename
+            std::pair<unsigned int,unsigned int> const& _size,
+            std::string const& _filename
         )
         {
             pngwriter png( _size.first, _size.second, 0, _filename.c_str( ) );
@@ -118,8 +118,8 @@ namespace writeOutFuncs
         void writeOutHDF5
         (
             float* _mem,
-            std::pair<unsigned int,unsigned int> const _size,
-            std::string const _filename
+            std::pair<unsigned int,unsigned int> const& _size,
+            std::string const& _filename
         )
         {
             splash::SerialDataCollector sdc( 0 );

--- a/src/imresh/io/writeOutFuncs/writeOutFuncs.hpp
+++ b/src/imresh/io/writeOutFuncs/writeOutFuncs.hpp
@@ -45,8 +45,8 @@ namespace writeOutFuncs
      */
     void justFree(
         float* _mem,
-        std::pair<unsigned int,unsigned int> const _size,
-        std::string const _filname
+        std::pair<unsigned int,unsigned int> const& _size,
+        std::string const& _filname
     );
 
 #   ifdef USE_PNG
@@ -55,8 +55,8 @@ namespace writeOutFuncs
          */
         void writeOutPNG(
             float* _mem,
-            std::pair<unsigned int,unsigned int> const _size,
-            std::string const _filename
+            std::pair<unsigned int,unsigned int> const& _size,
+            std::string const& _filename
         );
 #   endif
 
@@ -68,8 +68,8 @@ namespace writeOutFuncs
          */
         void writeOutHDF5(
             float* _mem,
-            std::pair<unsigned int,unsigned int> const _size,
-            std::string const _filename
+            std::pair<unsigned int,unsigned int> const& _size,
+            std::string const& _filename
         );
 #   endif
 

--- a/src/imresh/io/writeOutFuncs/writeOutFuncs.hpp
+++ b/src/imresh/io/writeOutFuncs/writeOutFuncs.hpp
@@ -44,8 +44,8 @@ namespace writeOutFuncs
      * on the filesystem.
      */
     void justFree(
-        float * _mem,
-        std::pair<unsigned, unsigned> const _size,
+        float* _mem,
+        std::pair<unsigned int,unsigned int> const _size,
         std::string const _filname
     );
 
@@ -54,8 +54,8 @@ namespace writeOutFuncs
          * Writes the reconstructed image to a PNG file.
          */
         void writeOutPNG(
-            float const * const _mem,
-            std::pair<unsigned, unsigned> const _size,
+            float* _mem,
+            std::pair<unsigned int,unsigned int> const _size,
             std::string const _filename
         );
 #   endif
@@ -67,8 +67,8 @@ namespace writeOutFuncs
          * This is done using libSplash.
          */
         void writeOutHDF5(
-            float const * const _mem,
-            std::pair<unsigned, unsigned> const _size,
+            float* _mem,
+            std::pair<unsigned int,unsigned int> const _size,
             std::string const _filename
         );
 #   endif

--- a/src/imresh/io/writeOutFuncs/writeOutFuncs.hpp
+++ b/src/imresh/io/writeOutFuncs/writeOutFuncs.hpp
@@ -44,9 +44,9 @@ namespace writeOutFuncs
      * on the filesystem.
      */
     void justFree(
-        float* _mem,
-        std::pair<unsigned int,unsigned int> const& _size,
-        std::string const& _filname
+        float * _mem,
+        std::pair<unsigned int,unsigned int> const _size,
+        std::string const _filname
     );
 
 #   ifdef USE_PNG
@@ -54,9 +54,9 @@ namespace writeOutFuncs
          * Writes the reconstructed image to a PNG file.
          */
         void writeOutPNG(
-            float* _mem,
-            std::pair<unsigned int,unsigned int> const& _size,
-            std::string const& _filename
+            float * _mem,
+            std::pair<unsigned int,unsigned int> const _size,
+            std::string const _filename
         );
 #   endif
 
@@ -67,9 +67,9 @@ namespace writeOutFuncs
          * This is done using libSplash.
          */
         void writeOutHDF5(
-            float* _mem,
-            std::pair<unsigned int,unsigned int> const& _size,
-            std::string const& _filename
+            float * _mem,
+            std::pair<unsigned int,unsigned int> const _size,
+            std::string const _filename
         );
 #   endif
 


### PR DESCRIPTION
As suggested while our meeting this implements calls to `delete[]` in the write out functions for proper memory management.

Fixes #27 