### PR TITLE
Reduce soft requirement to make it work on hypnos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3.1)
+cmake_minimum_required(VERSION 3.3.0)
 project(imresh)
 
 # Options


### PR DESCRIPTION
Seems to have worked with 3.3.0. It's only a minor version number from 3.3.1 anyway.
